### PR TITLE
Use proper CRC for flash parameter storage and refactor param save/load

### DIFF
--- a/Firmware/radio/main.c
+++ b/Firmware/radio/main.c
@@ -102,12 +102,9 @@ main(void)
 	g_board_frequency = BOARD_FREQUENCY_REG;
 	g_board_bl_version = BOARD_BL_VERSION_REG;
 
-	// try to load parameters; set them to defaults if that fails.
+	// Load parameters from flash or defaults
 	// this is done before hardware_init() to get the serial speed
-	// XXX default parameter selection should be based on board info
-	//
-	if (!param_load())
-		param_default();
+	param_load();
 
 	// setup boolean features
 	feature_mavlink_framing = param_get(PARAM_MAVLINK)?true:false;


### PR DESCRIPTION
Original checksum was extremely brittle; changed from sequential XOR to the crc16 used by the packet code.

Since changing the checksum code invalidates existing configuration data, took opportunity to refactor the save/load code and the in-flash data format, which also resolved some weird configuration corruption issues we've been seeing.
