### PR TITLE
Added missing *break* statement that prevented code from compilation

### DIFF
--- a/Firmware/radio/at.c
+++ b/Firmware/radio/at.c
@@ -206,6 +206,7 @@ at_timer(void)
 				break;
 			default:
 				// should never happen, but otherwise harmless
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
Without the `break`, I got the following error:

```
radio/at.c:210: error 230: label without statement
include/rules.mk:132: recipe for target 'obj/rfd900a/radio~rfd900a/at.rel' failed
make[1]: *** [obj/rfd900a/radio~rfd900a/at.rel] Error 1
make[1]: Leaving directory '/home/hacms/Documents/SiK/Firmware'
Makefile:94: recipe for target 'install~radio~rfd900a' failed
make: *** [install~radio~rfd900a] Error 2
```

With the `break` it compiles fine.
