### PR TITLE
Error import fdpexpect in some files in the folder Firmware/tools/

### DIFF
--- a/Firmware/tools/atcommander.py
+++ b/Firmware/tools/atcommander.py
@@ -3,7 +3,8 @@
 # Provide command line access to AT command set on radios
 #
 
-import serial, sys, argparse, time, fdpexpect
+import serial, sys, argparse, time
+from pexpect import fdpexpect
 
 class ATCommandSet(object):
     ''' Interface to the AT command set '''

--- a/Firmware/tools/console.py
+++ b/Firmware/tools/console.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # a trivial serial console
 
-import serial, sys, optparse, fdpexpect
+import serial, sys, optparse
+from pexpect import fdpexpect
 
 parser = optparse.OptionParser("console")
 parser.add_option("--baudrate", type='int', default=57600, help='baud rate')

--- a/Firmware/tools/rssi.py
+++ b/Firmware/tools/rssi.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # RSSI production test
 
-import serial, sys, optparse, time, fdpexpect
+import serial, sys, optparse, time
+import fdpexpect
 
 parser = optparse.OptionParser("update_mode")
 parser.add_option("--baudrate", type='int', default=57600, help='baud rate')

--- a/Firmware/tools/set_speed.py
+++ b/Firmware/tools/set_speed.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # set air data rate
 
-import serial, sys, optparse, time, fdpexpect
+import serial, sys, optparse, time
+from pexpect import fdpexpect
 
 parser = optparse.OptionParser("set_speed")
 parser.add_option("--baudrate", type='int', default=57600, help='baud rate')

--- a/Firmware/tools/set_sreg.py
+++ b/Firmware/tools/set_sreg.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # set air data rate
 
-import serial, sys, optparse, time, fdpexpect
+import serial, sys, optparse, time
+from pexpect import fdpexpect
 
 parser = optparse.OptionParser("set_speed")
 parser.add_option("--baudrate", type='int', default=57600, help='baud rate')

--- a/Firmware/tools/show_regs.py
+++ b/Firmware/tools/show_regs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # set air data rate
 
-import serial, sys, optparse, time, fdpexpect
+import serial, sys, optparse, time
+from pexpect import fdpexpect
 
 parser = optparse.OptionParser("show_regs")
 parser.add_option("--baudrate", type='int', default=57600, help='baud rate')

--- a/Firmware/tools/show_rssi.py
+++ b/Firmware/tools/show_rssi.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # set air data rate
 
-import serial, sys, optparse, time, fdpexpect
+import serial, sys, optparse, time
+from pexpect import fdpexpect
 
 parser = optparse.OptionParser("show_rssi")
 parser.add_option("--baudrate", type='int', default=57600, help='baud rate')

--- a/Firmware/tools/update_mode.py
+++ b/Firmware/tools/update_mode.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # put a HopeRF into update mode
 
-import serial, sys, optparse, time, fdpexpect
+import serial, sys, optparse, time
+from pexpect import fdpexpect
 
 parser = optparse.OptionParser("update_mode")
 parser.add_option("--baudrate", type='int', default=57600, help='baud rate')


### PR DESCRIPTION
**System Ubuntu 18.04 4.15.0-33-generic**
Executing some python scripts in /Firmware/tools/  appears the next error:

`Traceback (most recent call last):
  File "./show_regs.py", line 4, in <module>
    import serial, sys, optparse, time, fdpexpect
ImportError: No module named fdpexpect
`
This error can be avoided changing:
**import fdpexpect**
by:
**from pexpect import fdpexpect**

