### PR TITLE
Golay code is never included on non AES boards

### DIFF
--- a/Firmware/radio/radio.h
+++ b/Firmware/radio/radio.h
@@ -35,6 +35,10 @@
 #ifndef _RADIO_H_
 #define _RADIO_H_
 
+#ifndef INCLUDE_AES
+#define INCLUDE_GOLAY
+#endif
+
 /// @page hardware Notes on Hardware Allocation
 ///
 /// @section timers Timer Allocation


### PR DESCRIPTION
This is a pull request to fix issue #40 using the patch submitted in issue #40. It's a straight forward change and certainly seems worth building a new release.