### PR TITLE
Fix remaining packet loss on Si1060

### DIFF
--- a/Firmware/radio/main.c
+++ b/Firmware/radio/main.c
@@ -259,8 +259,10 @@ hardware_init(void)
 	// UART - set the configured speed
 	serial_init(param_get(PARAM_SERIAL_SPEED));
 
-	// set all interrupts to the same priority level
-	IP = 0;
+	// set interrupt priority level
+	IP = 0;  // default low priority
+	PS0 = 1; // UART0 high priority
+	PT2 = 1; // TIMER2 high priority
 
 	// global interrupt enable
 	EA = 1;


### PR DESCRIPTION
Adjust interrupt priorities such that the radio interrupt handler can be
preempted by the other two kinds of interrupts. This is important
because at least on Si1060-based modems the radio handler can take so
long we occasionally miss bytes on the serial RX line.

--

This fixes most of the packet loss observed on Si1060 radios. Some stats follow. I reasoned about whether making the radio handler preemptable opens some race condition, but it seems safe. No of the timer/serial interrupts call back into the radio stuff. And the timer-/serial-related code called by the radio handler should disable the respective interrupt if needed, irrespective of whether we are in the radio handler, nothing changes there.

## Mavtester stats

I tested this PR together with the change from #68, just to rule out any obscure regression there.

### Before (current master)

ISM01A v. ISM01A

    Veh:3060/263/86  GCS:90/3061/3017  pend:43 rates:43/2000 lat:29/233/132 bad:34/400 txbuf:86/100 rssi:139/169 noise:32/34 loss:26:0%/2:2% fixed:0/0

Holybro (GCS) v. ISM01A (vehicle)

    Veh:3060/267/88  GCS:90/3050/3006  pend:54 rates:43/2000 lat:30/237/134 bad:0/325 txbuf:83/100 rssi:201/157 noise:20/82 loss:36:1%/0:0% fixed:0/0

### After (with this and #68)

ISM01A v. ISM01A

    Veh:3060/267/88  GCS:90/3087/3043  pend:17 rates:43/2000 lat:39/243/138 bad:0/0 txbuf:88/100 rssi:135/181 noise:31/36 loss:0:0%/0:0% fixed:0/0

Holybro (GCS) v. ISM01A (vehicle)

    Veh:3060/267/88  GCS:90/3078/3034  pend:26 rates:43/2000 lat:27/241/133 bad:0/0 txbuf:83/100 rssi:201/157 noise:23/81 loss:0:0%/0:0% fixed:0/0

Holybro here stands for the Si1000 radio currently being sold. These were lucky runs, as I still observed some packet loss on ISM01A even with this patch applied. Could be these were better conditions from RF perspective. I also tested Holybro v. Holybro, and no difference there.

--
CC: @kaklik