### PR TITLE
firmware: support compiling on SDCC >=4.0.3

### DIFF
--- a/Firmware/include/compiler_defs.h
+++ b/Firmware/include/compiler_defs.h
@@ -193,6 +193,14 @@ typedef union UU32
 // NOP () macro support
 #define NOP() _asm NOP _endasm
 
+// In SDCC r11731 (version 4.0.3) the _*toa() functions were renamed to __*toa,
+// so we add the __ names to older compiler versions here.
+#if defined(__SDCC_REVISION) && (__SDCC_REVISION < 11731)
+#define __itoa  _itoa
+#define __uitoa _uitoa
+#define __ltoa  _ltoa
+#define __ultoa _ultoa
+#endif
 
 //-----------------------------------------------------------------------------
 
@@ -637,7 +645,7 @@ typedef union UU32
 
 //-----------------------------------------------------------------------------
 
-// Wickenhäuser
+// Wickenhï¿½user
 // http://www.wickenhaeuser.de
 
 #elif defined __UC__

--- a/Firmware/radio/printfl.c
+++ b/Firmware/radio/printfl.c
@@ -163,9 +163,9 @@ vprintfl(const char * fmt, va_list ap) __reentrant
 				char __idata * stri;
 
 				if (unsigned_flag) {
-					_ultoa(val, buffer, radix);
+					__ultoa(val, buffer, radix);
 				} else {
-					_ltoa(val, buffer, radix);
+					__ltoa(val, buffer, radix);
 				}
 				stri = buffer;
 				while (*stri) {


### PR DESCRIPTION
Hi, as per issue #67 the SDCC compiler renamed `_itoa`, `_uitoa`, `_ltoa` and `_ultoa` to `__itoa`, `__uitoa`, `__ltoa` and `__ultoa` respectively. 

This patch converts the only two calls I can find (both in `printfl.c`) to the new `__` syntax, and adds a few preprocessor directives to `compiler_defs.h` to alias the `__` versions to their old names in revisions of SDCC below the point where this was changed.

If it's desirable to maintain compatibility with compilers other than `sdcc` it may be worth doing this the other way around, or with a proper macro - happy to change that if you like - but this way seemed the least fraught with peril.

This builds with both SDCC 4.1.0 (latest release) and SDCC 3.8.0 (current Ubuntu Focal package) based on my own testing.