### PR TITLE
Feature for automatic transmission of HAM callsign

### DIFF
--- a/Firmware/radio/at.c
+++ b/Firmware/radio/at.c
@@ -465,12 +465,12 @@ at_ampersand(void)
 			case 'E':
 				// enables transmission of callsign (default every 10 minutes)
 				enable_callsign = true;
-				printf("Transmission of callsign enabled: %s",callsign);
+				printf("Transmission of callsign enabled: %s\n",callsign);
 				break;
 			case 'D':
 				// disables transmission of callsign
 				enable_callsign = false;
-				printf("Transmission of callsign disabled: %s",callsign);
+				printf("Transmission of callsign disabled: %s\n",callsign);
 				break;
 			case 'S':
 				// user is entering their callsign

--- a/Firmware/radio/ham.c
+++ b/Firmware/radio/ham.c
@@ -1,0 +1,51 @@
+// -*- Mode: C; c-basic-offset: 8; -*-
+//
+// Copyright (c) 2025 Alexis Nicole Benini, Ph.D.
+// www.alexisbenini.com
+// All Rights Reserved
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  o Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  o Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in
+//    the documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+// OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+///
+/// @file	parameters.h
+///
+/// Definitions for transmission of HAM radio callsign
+///
+
+#include "ham.h"
+#include <string.h>
+
+__xdata char callsign[CALLSIGN_MAX_LENGTH];
+__pdata uint16_t callsign_tx_interval_secs;
+__pdata bool enable_callsign;
+
+#pragma nooverlay
+
+void initialize_ham_callsign_tx_params()
+{
+	enable_callsign = false;
+	memcpy(callsign,"NOSIGN",7);
+	callsign_tx_interval_secs = 2; // 600;
+}

--- a/Firmware/radio/ham.c
+++ b/Firmware/radio/ham.c
@@ -29,9 +29,9 @@
 //
 
 ///
-/// @file	parameters.h
+/// @file	ham.c
 ///
-/// Definitions for transmission of HAM radio callsign
+/// Functions for transmission of HAM radio callsign
 ///
 
 #include "ham.h"

--- a/Firmware/radio/ham.h
+++ b/Firmware/radio/ham.h
@@ -1,0 +1,53 @@
+// -*- Mode: C; c-basic-offset: 8; -*-
+//
+// Copyright (c) 2025 Alexis Nicole Benini, Ph.D.
+// www.alexisbenini.com
+// All Rights Reserved
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  o Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  o Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in
+//    the documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+// OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+///
+/// @file	parameters.h
+///
+/// Definitions for transmission of HAM radio callsign
+///
+
+#ifndef _HAM_H_
+#define _HAM_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "cdt.h"
+
+#define MAX_CALLSIGN_INTERVAL_SEC 10*60       // According to FCC rules, the call sign must be transmitted at least every 10 minutes.
+#define CALLSIGN_MAX_LENGTH 8                 // This includes the initial "DE" sequence
+extern __xdata char callsign[CALLSIGN_MAX_LENGTH];   // This assumes that the operator is using a standard callsign length (6).
+                                              // However, some regions might use 7 characters. The length of this array includes also the \0 at the end
+extern __pdata uint16_t callsign_tx_interval_secs;   // This is set to 600 seconds (10 minutes) by default
+extern __pdata bool enable_callsign;                 // Set to false by default (no callsign transmission)
+
+void initialize_ham_callsign_tx_params();
+
+#endif	// _HAM_H_

--- a/Firmware/radio/ham.h
+++ b/Firmware/radio/ham.h
@@ -29,9 +29,9 @@
 //
 
 ///
-/// @file	parameters.h
+/// @file	ham.h
 ///
-/// Definitions for transmission of HAM radio callsign
+/// Function and parameters for transmission of HAM radio callsign
 ///
 
 #ifndef _HAM_H_

--- a/Firmware/radio/main.c
+++ b/Firmware/radio/main.c
@@ -41,6 +41,7 @@
 #include "tdm.h"
 #include "timer.h"
 #include "freq_hopping.h"
+#include "ham.h"
 
 #ifdef INCLUDE_AES
 #include "AES/aes.h"
@@ -128,6 +129,9 @@ main(void)
 
 	// do radio initialisation
 	radio_init();
+
+	// ham radio callsign initialization
+	initialize_ham_callsign_tx_params();
 
 	// turn on the receiver
 	if (!radio_receiver_on()) {


### PR DESCRIPTION
Hi,
I've added a feature to automatically transmit my HAM callsign when using the Sik Telemetry Radio v3. I decided to share it with you and ask if you are interested in adding my changes to your code base. Please find below more details about my changes.

**Rationale**

Licensed amateur radio operators are required by the Federal Communications Commission (FCC) to identify their station using their assigned callsign at regular intervals during transmissions. This requirement is outlined in Part 97 of the FCC rules (§97.119) and exists to ensure accountability and traceability within the amateur radio service. 

The callsign serves as a unique identifier that links their transmissions to their license, helping to prevent misuse of the airwaves and to facilitate enforcement in case of interference, unauthorized operation, or other violations. 
According to the regulation, the callsign must be transmitted at the end of a communication and at least every 10 minutes during ongoing transmissions. This applies whether the licensed amateur is transmitting voice, Morse code, or digital data. 

Even in cases where communication is automated (such as telemetry link) the station must still identify itself appropriately, typically by including the callsign in the data stream. 

I personally found out that I am supposed to transmit my callsign since, although I am transmitting at 915 MHz, my radio does not comply with Part 15 certification. Instead, it is operating under FCC Part 97 (Amateur Radio Service). 

**Disclaimer**: I am not a lawyer, and this is based on my understanding of the FCC regulations. I am not providing any legal advice.

**How this feature is implemented**

I have created custom AT commands that allow the user to set their callsign and the interval for the transmission of their callsign. It is important to note that this feature is disabled by default, but the user can enable it with the appropriate AT command.

Following is the list of AT commands:

- **AT&CE**: Enables the transmission of the HAM callsign. If the user does not set their callsign before enabling the transmission, the system will send the default "NOSIGN" callsign.
- **AT&CD**: Disables the transmission of the HAM callsign
- **AT&CS=xxxxx**: Sets the user's callsign. This option assumes that the operator is using a standard callsign length (6). However, some regions might use 7 characters (some special events as well as some regions outside the US might use 7 characters). The maximum length is set to 7.
- **AT&CI=yyy**: Sets the interval (in seconds) for the transmission of the callsign.

Default values:
- AT&CE=0
- AT&CS=NOSIGN
- AT&CI=600

I have tested it on my Holybro Sik telemetry radio v3 (915 Mhz @ 500 mW) and it seems to be working fine for my needs. Of course, I am more than happy to implement any improvement or bug fixing that other contributors migght suggest.

Thanks,
Alexis

www.alexisbenini.com
